### PR TITLE
refactor: GameLogic 함수 분리

### DIFF
--- a/src/game-logic.js
+++ b/src/game-logic.js
@@ -24,7 +24,6 @@ function createGameLogic() {
       setGameLoop();
       bindEvents();
     },
-    getNextGrowthStage,
   };
 }
 

--- a/src/game-logic.js
+++ b/src/game-logic.js
@@ -3,121 +3,131 @@ import EventBus from './event-bus.js';
 import GameState from './game-state.js';
 import Mushroom from './mushroom.js';
 
-const GameLogic = {
-  init() {
-    this.setGameLoop();
-    this.bindEvents();
-  },
+const GameLogic = createGameLogic();
+export default GameLogic;
 
-  setGameLoop() {
-    setInterval(() => this.growthCheck(), 1000);
-  },
+function createGameLogic() {
+  const setGameLoop = () => {
+    setInterval(() => checkMushroomGrowth(), 1000);
+  };
 
-  bindEvents() {
+  const bindEvents = () => {
     EventBus.on({
       from: FROM,
       e: CONFIG.EVENT_ID.GAME_LOGIC.FIELD_CLICKED,
-      callback: ({ fieldID }) => this.handleFieldClick({ fieldID }),
+      callback: ({ fieldID }) => handleFieldClick({ fieldID }),
     });
-  },
+  };
 
-  handleFieldClick({ fieldID }) {
-    const { mushroomID } = GameState.getField({ fieldID });
+  return {
+    init() {
+      setGameLoop();
+      bindEvents();
+    },
+    getNextGrowthStage,
+  };
+}
 
-    if (!mushroomID) {
-      this.plantNewMushroom({ fieldID });
+export function handleFieldClick({ fieldID }) {
+  const { mushroomID } = GameState.getField({ fieldID });
+
+  if (!mushroomID) {
+    plantNewMushroom({ fieldID });
+    return;
+  }
+
+  const mushroom = GameState.getMushroom({ mushroomID });
+  if (mushroom.growthStage !== CONFIG.GROWTH_STAGE.MATURE) {
+    return;
+  }
+
+  harvestMushroom({ fieldID, mushroomID: mushroom.id });
+}
+
+export function checkMushroomGrowth() {
+  const mushroomList = GameState.getMushroomList();
+
+  mushroomList.forEach((mushroom) => {
+    const { fieldID, plantedAt, growthTime, growthStage } = mushroom;
+    const now = Date.now();
+
+    if (!shouldMushroomGrow({ plantedAt, growthTime, growthStage, now }))
       return;
-    }
 
-    const mushroom = GameState.getMushroom({ mushroomID });
-    if (mushroom.growthStage !== CONFIG.GROWTH_STAGE.MATURE) {
-      return;
-    }
-
-    this.harvestMushroom({ fieldID, mushroomID: mushroom.id });
-  },
-
-  growthCheck() {
-    const mushroomList = GameState.getMushroomList();
-
-    mushroomList.forEach((mushroom) => {
-      const { fieldID, plantedAt, growthTime, growthStage } = mushroom;
-      const now = Date.now();
-
-      if (!this.shouldGrow({ plantedAt, growthTime, growthStage, now })) return;
-
-      const nextGrowthStage = this.getNextGrowthStage({
-        current: growthStage,
-      });
-
-      if (!nextGrowthStage) return;
-
-      this.growTo({
-        fieldID,
-        mushroomID: mushroom.id,
-        nextGrowthStage,
-      });
+    const nextGrowthStage = getNextGrowthStage({
+      current: growthStage,
     });
-  },
 
-  shouldGrow({ plantedAt, growthTime, growthStage, now }) {
-    if (growthStage === CONFIG.GROWTH_STAGE.MATURE) return false;
+    if (!nextGrowthStage) return;
 
-    const requiredTimeForCurrentStage =
-      growthStage === CONFIG.GROWTH_STAGE.MYCELIUM
-        ? growthTime.myceliumToFruiting
-        : growthTime.fruitingToMature;
-
-    const elapsed = now - plantedAt;
-
-    return elapsed >= requiredTimeForCurrentStage;
-  },
-
-  growTo({ mushroomID, nextGrowthStage }) {
-    EventBus.emit({
-      from: CONFIG.MODULE_ID.GAME_LOGIC,
-      e: CONFIG.EVENT_ID.GAME_STATE.UPDATE_MUSHROOM_GROWTH_STAGE,
-      data: { mushroomID, nextGrowthStage },
-    });
-  },
-
-  getNextGrowthStage({ current }) {
-    const { MYCELIUM, FRUITING, MATURE } = CONFIG.GROWTH_STAGE;
-
-    switch (current) {
-      case MYCELIUM:
-        return FRUITING;
-
-      case FRUITING:
-        return MATURE;
-
-      default:
-        return null;
-    }
-  },
-
-  plantNewMushroom({ fieldID }) {
-    const newMushroom = new Mushroom({
+    growTo({
       fieldID,
-      mushroomType: CONFIG.MUSHROOM.RED_CAP.type,
+      mushroomID: mushroom.id,
+      nextGrowthStage,
     });
+  });
+}
 
-    EventBus.emit({
-      from: FROM,
-      e: CONFIG.EVENT_ID.GAME_STATE.SET_NEW_MUSHROOM,
-      data: { ...newMushroom },
-    });
-  },
+export function shouldMushroomGrow({
+  plantedAt,
+  growthTime,
+  growthStage,
+  now,
+}) {
+  if (growthStage === CONFIG.GROWTH_STAGE.MATURE) return false;
 
-  harvestMushroom({ fieldID, mushroomID }) {
-    EventBus.emit({
-      from: FROM,
-      e: CONFIG.EVENT_ID.GAME_STATE.HARVEST_MUSHROOM,
-      data: { fieldID, mushroomID },
-    });
-  },
-};
+  const requiredTimeForCurrentStage =
+    growthStage === CONFIG.GROWTH_STAGE.MYCELIUM
+      ? growthTime.myceliumToFruiting
+      : growthTime.fruitingToMature;
 
-export default GameLogic;
+  const elapsed = now - plantedAt;
+
+  return elapsed >= requiredTimeForCurrentStage;
+}
+
+export function getNextGrowthStage({ current }) {
+  const { MYCELIUM, FRUITING, MATURE } = CONFIG.GROWTH_STAGE;
+
+  switch (current) {
+    case MYCELIUM:
+      return FRUITING;
+
+    case FRUITING:
+      return MATURE;
+
+    default:
+      return null;
+  }
+}
+
+export function growTo({ mushroomID, nextGrowthStage }) {
+  EventBus.emit({
+    from: CONFIG.MODULE_ID.GAME_LOGIC,
+    e: CONFIG.EVENT_ID.GAME_STATE.UPDATE_MUSHROOM_GROWTH_STAGE,
+    data: { mushroomID, nextGrowthStage },
+  });
+}
+
+export function plantNewMushroom({ fieldID }) {
+  const newMushroom = new Mushroom({
+    fieldID,
+    mushroomType: CONFIG.MUSHROOM.RED_CAP.type,
+  });
+
+  EventBus.emit({
+    from: FROM,
+    e: CONFIG.EVENT_ID.GAME_STATE.SET_NEW_MUSHROOM,
+    data: { ...newMushroom },
+  });
+}
+
+export function harvestMushroom({ fieldID, mushroomID }) {
+  EventBus.emit({
+    from: FROM,
+    e: CONFIG.EVENT_ID.GAME_STATE.HARVEST_MUSHROOM,
+    data: { fieldID, mushroomID },
+  });
+}
 
 const FROM = CONFIG.MODULE_ID.GAME_LOGIC;

--- a/src/game-logic.test.js
+++ b/src/game-logic.test.js
@@ -1,84 +1,36 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import CONFIG from './config';
 import EventBus from './event-bus';
-import GameLogic from './game-logic';
+import {
+  shouldMushroomGrow,
+  getNextGrowthStage,
+  handleFieldClick,
+  checkMushroomGrowth,
+  growTo,
+  plantNewMushroom,
+  harvestMushroom,
+} from './game-logic';
 import GameState from './game-state';
 import Mushroom from './mushroom';
 
 let spyOnEmit;
 let spyOnGetField;
 let spyOnGetMushroom;
+let spyOnGetMushroomList;
 
 beforeEach(() => {
   spyOnEmit = vi.spyOn(EventBus, 'emit');
   spyOnGetField = vi.spyOn(GameState, 'getField');
   spyOnGetMushroom = vi.spyOn(GameState, 'getMushroom');
+  spyOnGetMushroomList = vi.spyOn(GameState, 'getMushroomList');
 });
 
 afterEach(() => {
   vi.restoreAllMocks();
 });
 
-describe('handleFieldClick', () => {
-  const fieldID = 'field-1';
-  const mushroom = new Mushroom({
-    fieldID,
-    mushroomType: CONFIG.MUSHROOM.RED_CAP.type,
-  });
-
-  it('버섯이 없으면 새 버섯을 심는 이벤트를 발생시킨다', () => {
-    GameLogic.handleFieldClick({ fieldID });
-
-    expect(spyOnEmit).toHaveBeenCalledWith(
-      expect.objectContaining({
-        from: CONFIG.MODULE_ID.GAME_LOGIC,
-        e: CONFIG.EVENT_ID.GAME_STATE.SET_NEW_MUSHROOM,
-      }),
-    );
-  });
-
-  it('버섯이 성장 중이라면 수확 이벤트를 발생시키지 않는다', () => {
-    spyOnGetField.mockReturnValue({
-      fieldID,
-      mushroomID: mushroom.id,
-    });
-    spyOnGetMushroom.mockReturnValue({
-      ...mushroom,
-      growthStage: CONFIG.GROWTH_STAGE.MYCELIUM,
-    });
-
-    GameLogic.handleFieldClick({ fieldID });
-
-    expect(spyOnEmit).not.toHaveBeenCalledWith(
-      expect.objectContaining({
-        from: CONFIG.MODULE_ID.GAME_LOGIC,
-        e: CONFIG.EVENT_ID.GAME_STATE.HARVEST_MUSHROOM,
-      }),
-    );
-  });
-
-  it('버섯이 성숙 단계라면 수확 이벤트를 발생시킨다', () => {
-    spyOnGetField.mockReturnValue({
-      fieldID,
-      mushroomID: mushroom.id,
-    });
-    spyOnGetMushroom.mockReturnValue({
-      ...mushroom,
-      growthStage: CONFIG.GROWTH_STAGE.MATURE,
-    });
-
-    GameLogic.handleFieldClick({ fieldID });
-
-    expect(spyOnEmit).toHaveBeenCalledWith(
-      expect.objectContaining({
-        from: CONFIG.MODULE_ID.GAME_LOGIC,
-        e: CONFIG.EVENT_ID.GAME_STATE.HARVEST_MUSHROOM,
-      }),
-    );
-  });
-});
-
-describe('shouldGrow', () => {
+// 단위 테스트
+describe('shouldMushroomGrow', () => {
   const MOCK_START_TIME = 1000000;
   const GROWTH_TIME = {
     myceliumToFruiting: 1000,
@@ -90,7 +42,7 @@ describe('shouldGrow', () => {
     const now = MOCK_START_TIME + 10000;
     const growthStage = CONFIG.GROWTH_STAGE.MYCELIUM;
 
-    const result = GameLogic.shouldGrow({
+    const result = shouldMushroomGrow({
       plantedAt,
       growthTime: GROWTH_TIME,
       growthStage,
@@ -105,7 +57,7 @@ describe('shouldGrow', () => {
     const now = MOCK_START_TIME + 999;
     const growthStage = CONFIG.GROWTH_STAGE.FRUITING;
 
-    const result = GameLogic.shouldGrow({
+    const result = shouldMushroomGrow({
       plantedAt,
       growthTime: GROWTH_TIME,
       growthStage,
@@ -120,7 +72,7 @@ describe('shouldGrow', () => {
     const now = MOCK_START_TIME + 30000;
     const growthStage = CONFIG.GROWTH_STAGE.MATURE;
 
-    const result = GameLogic.shouldGrow({
+    const result = shouldMushroomGrow({
       plantedAt,
       growthTime: GROWTH_TIME,
       growthStage,
@@ -131,12 +83,144 @@ describe('shouldGrow', () => {
   });
 });
 
-it('growTo: 버섯 성장 이벤트를 트리거해야 한다', () => {
+describe('getNextGrowthStage', () => {
+  //Given
+  it.each`
+    currentGrowthStage              | expected
+    ${CONFIG.GROWTH_STAGE.MYCELIUM} | ${CONFIG.GROWTH_STAGE.FRUITING}
+    ${CONFIG.GROWTH_STAGE.FRUITING} | ${CONFIG.GROWTH_STAGE.MATURE}
+    ${CONFIG.GROWTH_STAGE.MATURE}   | ${null}
+  `(
+    '$currentGrowthStage의 다음 단계는 $expected이다',
+    ({ currentGrowthStage, expected }) => {
+      // When
+      const nextGrowthStage = getNextGrowthStage({
+        current: currentGrowthStage,
+      });
+
+      // Then
+      expect(nextGrowthStage).toBe(expected);
+    },
+  );
+});
+
+// 통합 테스트
+describe('handleFieldClick', () => {
+  // Given
+  const fieldID = 'field-1';
+  const mushroom = new Mushroom({
+    fieldID,
+    mushroomType: CONFIG.MUSHROOM.RED_CAP.type,
+  });
+
+  it('버섯이 없으면 새 버섯을 심는 이벤트를 발생시킨다', () => {
+    // Given
+    spyOnGetField.mockReturnValue({ fieldID, mushroomID: null });
+
+    // When
+    handleFieldClick({ fieldID });
+
+    // Then
+    expect(spyOnEmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        from: CONFIG.MODULE_ID.GAME_LOGIC,
+        e: CONFIG.EVENT_ID.GAME_STATE.SET_NEW_MUSHROOM,
+      }),
+    );
+  });
+
+  it('버섯이 성장 중이라면 수확 이벤트를 발생시키지 않는다', () => {
+    // Given
+    spyOnGetField.mockReturnValue({
+      fieldID,
+      mushroomID: mushroom.id,
+    });
+    spyOnGetMushroom.mockReturnValue({
+      ...mushroom,
+      growthStage: CONFIG.GROWTH_STAGE.MYCELIUM,
+    });
+
+    // When
+    handleFieldClick({ fieldID });
+
+    // Then
+    expect(spyOnEmit).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        from: CONFIG.MODULE_ID.GAME_LOGIC,
+        e: CONFIG.EVENT_ID.GAME_STATE.HARVEST_MUSHROOM,
+      }),
+    );
+  });
+
+  it('버섯이 성숙 단계라면 수확 이벤트를 발생시킨다', () => {
+    // Given
+    spyOnGetField.mockReturnValue({
+      fieldID,
+      mushroomID: mushroom.id,
+    });
+    spyOnGetMushroom.mockReturnValue({
+      ...mushroom,
+      growthStage: CONFIG.GROWTH_STAGE.MATURE,
+    });
+
+    // When
+    handleFieldClick({ fieldID });
+
+    // Then
+    expect(spyOnEmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        from: CONFIG.MODULE_ID.GAME_LOGIC,
+        e: CONFIG.EVENT_ID.GAME_STATE.HARVEST_MUSHROOM,
+      }),
+    );
+  });
+});
+
+describe('growthCheck', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('시간이 지나 버섯이 성장해야 할 때, 성장 이벤트를 발생시킨다', () => {
+    // Given
+    const fieldID = 'field-1';
+    const mushroomToGrow = new Mushroom({
+      fieldID,
+      mushroomType: CONFIG.MUSHROOM.RED_CAP.type,
+    }); // plantedAt: Date.now()
+
+    spyOnGetMushroomList.mockReturnValue([mushroomToGrow]);
+    vi.advanceTimersByTime(mushroomToGrow.growthTime.myceliumToFruiting + 1);
+
+    // When
+    checkMushroomGrowth();
+
+    // Then
+    expect(spyOnEmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        e: CONFIG.EVENT_ID.GAME_STATE.UPDATE_MUSHROOM_GROWTH_STAGE,
+        data: {
+          mushroomID: mushroomToGrow.id,
+          nextGrowthStage: CONFIG.GROWTH_STAGE.FRUITING,
+        },
+      }),
+    );
+  });
+});
+
+it('growTo: 버섯 성장 이벤트를 발생시킨다', () => {
+  // Given
   const mushroomID = 'field-1_redcap';
   const nextGrowthStage = CONFIG.GROWTH_STAGE.FRUITING;
 
-  GameLogic.growTo({ mushroomID, nextGrowthStage });
+  // When
+  growTo({ mushroomID, nextGrowthStage });
 
+  // Then
   expect(spyOnEmit).toHaveBeenCalledWith({
     from: CONFIG.MODULE_ID.GAME_LOGIC,
     e: CONFIG.EVENT_ID.GAME_STATE.UPDATE_MUSHROOM_GROWTH_STAGE,
@@ -147,26 +231,38 @@ it('growTo: 버섯 성장 이벤트를 트리거해야 한다', () => {
   });
 });
 
-it('plantNewMushroom: 새로운 버섯을 심는 이벤트를 트리거해야 한다', () => {
+it('plantNewMushroom: 새로운 버섯을 심는 이벤트를 발생시킨다', () => {
+  // Given
   const fieldID = 'field-1';
 
-  GameLogic.plantNewMushroom({ fieldID });
+  // When
+  plantNewMushroom({ fieldID });
 
+  // Then
   expect(spyOnEmit).toHaveBeenCalledWith({
     from: CONFIG.MODULE_ID.GAME_LOGIC,
     e: CONFIG.EVENT_ID.GAME_STATE.SET_NEW_MUSHROOM,
+    data: expect.objectContaining({
+      fieldID,
+    }),
+  });
+});
+
+it('harvestMushroom: 버섯을 수확하는 이벤트를 발생시킨다', () => {
+  // Given
+  const fieldID = 'field-1';
+  const mushroomID = 'mushroom-1';
+
+  // When
+  harvestMushroom({ fieldID, mushroomID });
+
+  // Then
+  expect(spyOnEmit).toHaveBeenCalledWith({
+    from: CONFIG.MODULE_ID.GAME_LOGIC,
+    e: CONFIG.EVENT_ID.GAME_STATE.HARVEST_MUSHROOM,
     data: {
       fieldID,
-      growthStage: CONFIG.GROWTH_STAGE.MYCELIUM,
-      growthTime: {
-        fruitingToMature: expect.any(Number),
-        myceliumToFruiting: expect.any(Number),
-      },
-      id: expect.any(String),
-      name: expect.any(String),
-      plantedAt: expect.any(Number),
-      rarity: expect.any(Number),
-      type: expect.any(String),
+      mushroomID,
     },
   });
 });


### PR DESCRIPTION
- literal object 에서 팩토리 패턴 함수로 전환: 내부 API는 감추고 공개 API 식별 용이성 향상
- 내부 함수는 named export로 분리하여 테스트 코드에서 import 할 수 있도록 수정 